### PR TITLE
Make ubint instantiation platform agnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,8 @@ jobs:
         include:
           - os: ubuntu-latest
             shell: bash
-          # macOS disabled due to inexplicable compilation error related to GitHub Actions
-          # - os: macos-latest
-          #   shell: bash
+          - os: macos-latest
+            shell: bash
           # Windows disabled due to build failures related to GitHub Actions
           # - os: windows-latest
           #   shell: 'msys2 {0}'

--- a/src/cryptocontextimpl.cpp
+++ b/src/cryptocontextimpl.cpp
@@ -14,7 +14,7 @@ void wrap_CryptoContextImpl(jlcxx::Module& mod) {
         wrapped.method("KeyGen", &WrappedT::KeyGen);
         wrapped.method("EvalMultKeyGen", &WrappedT::EvalMultKeyGen);
         wrapped.method("EvalRotateKeyGen", &WrappedT::EvalRotateKeyGen);
-        using ParamType = lbcrypto::ILDCRTParams<bigintdyn::ubint<long unsigned int> >;
+        using ParamType = lbcrypto::ILDCRTParams<bigintdyn::ubint<expdtype> >;
         wrapped.method("MakeCKKSPackedPlaintext",
             static_cast<lbcrypto::Plaintext (WrappedT::*)(const std::vector<double>&,
                                                           size_t,

--- a/src/ildcrtparams.cpp
+++ b/src/ildcrtparams.cpp
@@ -5,6 +5,6 @@
 
 void wrap_ILDCRTParams(jlcxx::Module& mod) {
   mod.add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>>("ILDCRTParams")
-    .apply<lbcrypto::ILDCRTParams<bigintdyn::ubint<long unsigned int>>>([](auto wrapped) {});
+    .apply<lbcrypto::ILDCRTParams<bigintdyn::ubint<expdtype>>>([](auto wrapped) {});
 }
 

--- a/src/ubint.cpp
+++ b/src/ubint.cpp
@@ -5,6 +5,6 @@
 
 void wrap_ubint(jlcxx::Module& mod) {
   mod.add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>>("ubint")
-    .apply<bigintdyn::ubint<long unsigned int>>([](auto wrapped) {});
+    .apply<bigintdyn::ubint<expdtype>>([](auto wrapped) {});
 }
 


### PR DESCRIPTION
Before, we used the literal type `long unsigned int`, which could be wrong on some platforms. We now use `expdtype`, which is defined by OpenFHE and denotes the actual type used.