### PR TITLE
Wrap more OpenFHE functions

### DIFF
--- a/src/ciphertextimpl.cpp
+++ b/src/ciphertextimpl.cpp
@@ -8,6 +8,18 @@ void wrap_CiphertextImpl(jlcxx::Module& mod) {
                                                      jlcxx::julia_base_type<lbcrypto::CryptoObject<lbcrypto::DCRTPoly>>())
     .apply<lbcrypto::CiphertextImpl<lbcrypto::DCRTPoly>>([](auto wrapped) {
         typedef typename decltype(wrapped)::type WrappedT;
+
+        wrapped.method("GetNoiseScaleDeg", &WrappedT::GetNoiseScaleDeg);
+        wrapped.method("SetNoiseScaleDeg", &WrappedT::SetNoiseScaleDeg);
         wrapped.method("GetLevel", &WrappedT::GetLevel);
+        wrapped.method("SetLevel", &WrappedT::SetLevel);
+        wrapped.method("GetHopLevel", &WrappedT::GetHopLevel);
+        wrapped.method("SetHopLevel", &WrappedT::SetHopLevel);
+        wrapped.method("GetScalingFactor", &WrappedT::GetScalingFactor);
+        wrapped.method("SetScalingFactor", &WrappedT::SetScalingFactor);
+        wrapped.method("GetSlots", &WrappedT::GetSlots);
+        wrapped.method("SetSlots", &WrappedT::SetSlots);
+        wrapped.method("Clone", &WrappedT::Clone);
+        wrapped.method("CloneZero", &WrappedT::CloneZero);
       });
 }

--- a/src/cryptocontextimpl.cpp
+++ b/src/cryptocontextimpl.cpp
@@ -8,12 +8,22 @@ void wrap_CryptoContextImpl(jlcxx::Module& mod) {
   mod.add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>>("CryptoContextImpl", jlcxx::julia_base_type<lbcrypto::Serializable>())
     .apply<lbcrypto::CryptoContextImpl<lbcrypto::DCRTPoly>>([](auto wrapped) {
         typedef typename decltype(wrapped)::type WrappedT;
+
+        // Enable
         wrapped.method("Enable",
             static_cast<void (WrappedT::*)(lbcrypto::PKESchemeFeature)>(&WrappedT::Enable));
+
+        // Key generation level
+        wrapped.method("GetKeyGenLevel", &WrappedT::GetKeyGenLevel);
+        wrapped.method("SetKeyGenLevel", &WrappedT::SetKeyGenLevel);
+
+        wrapped.method("GetCyclotomicOrder", &WrappedT::GetCyclotomicOrder);
         wrapped.method("GetRingDimension", &WrappedT::GetRingDimension);
+        wrapped.method("GetModulus", &WrappedT::GetModulus);
+        wrapped.method("GetRootOfUnity", &WrappedT::GetRootOfUnity);
+
         wrapped.method("KeyGen", &WrappedT::KeyGen);
-        wrapped.method("EvalMultKeyGen", &WrappedT::EvalMultKeyGen);
-        wrapped.method("EvalRotateKeyGen", &WrappedT::EvalRotateKeyGen);
+
         using ParamType = lbcrypto::ILDCRTParams<bigintdyn::ubint<expdtype> >;
         wrapped.method("MakeCKKSPackedPlaintext",
             static_cast<lbcrypto::Plaintext (WrappedT::*)(const std::vector<double>&,
@@ -21,10 +31,39 @@ void wrap_CryptoContextImpl(jlcxx::Module& mod) {
                                                           uint32_t,
                                                           const std::shared_ptr<ParamType>,
                                                           usint) const>(&WrappedT::MakeCKKSPackedPlaintext));
+
+        // Encrypt
+        wrapped.method("Encrypt",
+            static_cast<lbcrypto::Ciphertext<lbcrypto::DCRTPoly>
+                        (WrappedT::*)(const lbcrypto::Plaintext&,
+                                      const lbcrypto::PublicKey<lbcrypto::DCRTPoly>) const>(&WrappedT::Encrypt));
         wrapped.method("Encrypt",
             static_cast<lbcrypto::Ciphertext<lbcrypto::DCRTPoly>
                         (WrappedT::*)(const lbcrypto::PublicKey<lbcrypto::DCRTPoly>,
                                       lbcrypto::Plaintext) const>(&WrappedT::Encrypt));
+        wrapped.method("Encrypt",
+            static_cast<lbcrypto::Ciphertext<lbcrypto::DCRTPoly>
+                        (WrappedT::*)(const lbcrypto::Plaintext&,
+                                      const lbcrypto::PrivateKey<lbcrypto::DCRTPoly>) const>(&WrappedT::Encrypt));
+        wrapped.method("Encrypt",
+            static_cast<lbcrypto::Ciphertext<lbcrypto::DCRTPoly>
+                        (WrappedT::*)(const lbcrypto::PrivateKey<lbcrypto::DCRTPoly>,
+                                      lbcrypto::Plaintext) const>(&WrappedT::Encrypt));
+
+        // Decrypt
+        wrapped.method("Decrypt",
+            static_cast<lbcrypto::DecryptResult
+                        (WrappedT::*)(lbcrypto::ConstCiphertext<lbcrypto::DCRTPoly>,
+                                      const lbcrypto::PrivateKey<lbcrypto::DCRTPoly>,
+                                      lbcrypto::Plaintext*)>(&WrappedT::Decrypt));
+        wrapped.method("Decrypt",
+            static_cast<lbcrypto::DecryptResult
+                        (WrappedT::*)(const lbcrypto::PrivateKey<lbcrypto::DCRTPoly>,
+                                      lbcrypto::ConstCiphertext<lbcrypto::DCRTPoly>,
+                                      lbcrypto::Plaintext*)>(&WrappedT::Decrypt));
+
+        // EvalNegate
+        wrapped.method("EvalNegate", &WrappedT::EvalNegate);
 
         // EvalAdd
         // ConstCiphertext + ConstCiphertext
@@ -80,6 +119,8 @@ void wrap_CryptoContextImpl(jlcxx::Module& mod) {
                         (WrappedT::*)(double,
                                       lbcrypto::ConstCiphertext<lbcrypto::DCRTPoly>) const>(&WrappedT::EvalSub));
 
+        wrapped.method("EvalMultKeyGen", &WrappedT::EvalMultKeyGen);
+
         // EvalMult
         // ConstCiphertext * ConstCiphertext
         wrapped.method("EvalMult",
@@ -107,18 +148,29 @@ void wrap_CryptoContextImpl(jlcxx::Module& mod) {
                         (WrappedT::*)(double,
                                       lbcrypto::ConstCiphertext<lbcrypto::DCRTPoly>) const>(&WrappedT::EvalMult));
 
-        wrapped.method("EvalNegate", &WrappedT::EvalNegate);
+        wrapped.method("EvalSquare", &WrappedT::EvalSquare);
+
+        wrapped.method("EvalMultNoRelin", &WrappedT::EvalMultNoRelin);
+        wrapped.method("Relinearize", &WrappedT::Relinearize);
+        wrapped.method("RelinearizeInPlace", &WrappedT::RelinearizeInPlace);
+
         wrapped.method("EvalRotate", &WrappedT::EvalRotate);
-        wrapped.method("Decrypt",
-            static_cast<lbcrypto::DecryptResult
-                        (WrappedT::*)(lbcrypto::ConstCiphertext<lbcrypto::DCRTPoly>,
-                                      const lbcrypto::PrivateKey<lbcrypto::DCRTPoly>,
-                                      lbcrypto::Plaintext*)>(&WrappedT::Decrypt));
-        wrapped.method("Decrypt",
-            static_cast<lbcrypto::DecryptResult
-                        (WrappedT::*)(const lbcrypto::PrivateKey<lbcrypto::DCRTPoly>,
-                                      lbcrypto::ConstCiphertext<lbcrypto::DCRTPoly>,
-                                      lbcrypto::Plaintext*)>(&WrappedT::Decrypt));
+        wrapped.method("EvalRotateKeyGen", &WrappedT::EvalRotateKeyGen);
+
+        wrapped.method("ComposedEvalMult", &WrappedT::ComposedEvalMult);
+        wrapped.method("Rescale", &WrappedT::Rescale);
+        wrapped.method("RescaleInPlace", &WrappedT::RescaleInPlace);
+        wrapped.method("ModReduce", &WrappedT::ModReduce);
+        wrapped.method("ModReduceInPlace", &WrappedT::ModReduceInPlace);
+
+        wrapped.method("EvalSin", &WrappedT::EvalSin);
+        wrapped.method("EvalCos", &WrappedT::EvalCos);
+        wrapped.method("EvalLogistic", &WrappedT::EvalSin);
+        wrapped.method("EvalDivide", &WrappedT::EvalDivide);
+
+        wrapped.method("EvalSumKeyGen", &WrappedT::EvalSumKeyGen);
+        wrapped.method("EvalSum", &WrappedT::EvalSum);
+
         wrapped.method("EvalBootstrapSetup", &WrappedT::EvalBootstrapSetup);
         wrapped.method("EvalBootstrapKeyGen", &WrappedT::EvalBootstrapKeyGen);
         wrapped.method("EvalBootstrap", &WrappedT::EvalBootstrap);

--- a/src/plaintextimpl.cpp
+++ b/src/plaintextimpl.cpp
@@ -3,7 +3,22 @@
 
 void wrap_PlaintextImpl(jlcxx::Module& mod) {
   mod.add_type<lbcrypto::PlaintextImpl>("PlaintextImpl")
+    .method("GetScalingFactor", &lbcrypto::PlaintextImpl::GetScalingFactor)
+    .method("SetScalingFactor", &lbcrypto::PlaintextImpl::SetScalingFactor)
+    .method("IsEncoded", &lbcrypto::PlaintextImpl::IsEncoded)
+    .method("GetElementRingDimension", &lbcrypto::PlaintextImpl::GetElementRingDimension)
+    .method("GetLength", &lbcrypto::PlaintextImpl::GetLength)
     .method("SetLength", &lbcrypto::PlaintextImpl::SetLength)
+    .method("GetNoiseScaleDeg", &lbcrypto::PlaintextImpl::GetNoiseScaleDeg)
+    .method("SetNoiseScaleDeg", &lbcrypto::PlaintextImpl::SetNoiseScaleDeg)
+    .method("GetLevel", &lbcrypto::PlaintextImpl::GetLevel)
+    .method("SetLevel", &lbcrypto::PlaintextImpl::SetLevel)
+    .method("GetSlots", &lbcrypto::PlaintextImpl::GetSlots)
+    .method("SetSlots", &lbcrypto::PlaintextImpl::SetSlots)
+    .method("GetLogError", &lbcrypto::PlaintextImpl::GetLogError)
     .method("GetLogPrecision", &lbcrypto::PlaintextImpl::GetLogPrecision)
+    .method("GetStringValue", &lbcrypto::PlaintextImpl::GetStringValue)
+    .method("GetCoefPackedValue", &lbcrypto::PlaintextImpl::GetCoefPackedValue)
+    .method("GetPackedValue", &lbcrypto::PlaintextImpl::GetPackedValue)
     .method("GetRealPackedValue", &lbcrypto::PlaintextImpl::GetRealPackedValue);
 }


### PR DESCRIPTION
For `Ciphertext`, add the following methods:
* `GetNoiseScaleDeg`
* `SetNoiseScaleDeg`
* (`GetLevel`)
* `SetLevel`
* `GetHopLevel`
* `SetHopLevel`
* `GetScalingFactor`
* `SetScalingFactor`
* `GetSlots`
* `SetSlots`
* `Clone`
* `CloneZero`

For `Plaintext`, add the following methods:
* `GetScalingFactor`
* `SetScalingFactor`
* `IsEncoded`
* `GetElementRingDimension`
* `GetLength`
* (`SetLength`)
* `GetNoiseScaleDeg`
* `SetNoiseScaleDeg`
* `GetLevel`
* `SetLevel`
* `GetSlots`
* `GetSlots`
* `GetLogError`
* (`GetLogPrecision`)
* `GetStringValue`
* `GetCoefPackedValue`
* `GetPackedValue`
* (`GetRealPackedValue`)

For `CryptoContext`, add the following methods:
* `<many>`